### PR TITLE
Add support for three new SG-1000 games: The Castle, Magical Kid Wiz,…

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -803,7 +803,7 @@ always @(posedge clk_sys) begin
 			systeme <= 1'b0;
 		load_sc <= sc_file;
 		load_sg <= sg_file;
-		// Large .sg/.sc images use the Survivors paging latch family:
+		// Large .sc images may use the Survivors paging latch family:
 		// >32KB = multicart-style banking, >2MB = 128-slot megacart banking.
 		load_sc_multicart <= load_sc_multicart | (sgsc_file & (ioctl_addr > 25'h07FFF));
 		load_sc_megacart <= load_sc_megacart | (sgsc_file & (ioctl_addr > 25'h1FFFFF));
@@ -811,8 +811,9 @@ always @(posedge clk_sys) begin
 	end;
 	if (old_download & ~cart_download) begin
 		sc3000_auto <= load_sc;
-		sc_multicart_auto <= (load_sc | load_sg) & load_sc_multicart;
-		sc_megacart_auto <= (load_sc | load_sg) & load_sc_megacart;
+		// Restrict Survivors paging auto-detection to explicit .sc loads.
+		sc_multicart_auto <= load_sc & load_sc_multicart;
+		sc_megacart_auto <= load_sc & load_sc_megacart;
 		palettemode <= load_sg;
 		if (load_sc) begin
 			if (!status[58]) begin

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -1113,11 +1113,15 @@ port map(
 	-- CRC16 of last 8KB block:
 	--   FA Tetris (Korea) (Unl)                          0x890A  [linear, 32KB]
 	--   Flashpoint (Korea) (Unl)                         0x4742  [linear, 32KB]
+	--   The Castle (Taiwan) (Unl)                        0xF6EE  [linear/type 11]
+	--   Magical Kid Wiz (Taiwan) (Unl)                   0xD935  [linear/type 11]
 	--   Rally-X (Taiwan) (English Logo) (Unl)            0x8D9A  [dahjee_typeb, 32KB]
 	--   Road Fighter (Taiwan) (English Logo) (Unl)       0x24BE  [dahjee_typeb, 32KB]
 	mapper_linear <= '1' when (
 		rom_crc16_run = x"890A" or  -- FA Tetris (Korea)
 		rom_crc16_run = x"4742" or  -- Flashpoint (Korea)
+		rom_crc16_run = x"F6EE" or  -- The Castle (Taiwan)
+		rom_crc16_run = x"D935" or  -- Magical Kid Wiz (Taiwan)
 		rom_crc16_run = x"8D9A" or  -- Rally-X (English Logo)
 		rom_crc16_run = x"24BE"     -- Road Fighter (English Logo)
 	) else '0';
@@ -1139,9 +1143,11 @@ port map(
 	-- CRC16 of last 8KB block:
 	--   Rally-X (Taiwan) (Chinese Logo) (Unl)            0xD6ED  [32KB] (confirmed working)
 	--   Road Fighter (Taiwan) (Chinese Logo) (Unl)       0x7B1C  [32KB] (confirmed working)
+	--   Bomberman Special (Taiwan) (Chinese Logo)         0x683D
 	mapper_dahjee_a <= '1' when (
 		rom_crc16_run = x"D6ED" or  -- Rally-X (Taiwan) (Chinese Logo)
-		rom_crc16_run = x"7B1C"     -- Road Fighter (Taiwan) (Chinese Logo)
+		rom_crc16_run = x"7B1C" or  -- Road Fighter (Taiwan) (Chinese Logo)
+		rom_crc16_run = x"683D"     -- Bomberman Special (Taiwan, Chinese Logo)
 	) else '0';
 
 	-- 4-PAK All Action (Australia) (Unl)


### PR DESCRIPTION
… Bomberman Special (#185)

* Clear bk_pending when download starts

Add explicit check to clear bk_pending on the transition into downloading (~old_downloading & downloading). This prevents a lingering backup-pending flag when a new download begins while preserving the existing logic that sets bk_pending on bk_ena && ~OSD_STATUS && bk_save_write and clears it when bk_state is active. Change applied in SMS.sv.

* Add Meka mapper 11 and Dahjee Type A expansion

Introduce support for MEKA mapper 11 and Dahjee Type A expansion.

New Master System games supported:

- FA Tetris (Korea) (Unl)
- Flashpoint (Korea) (Unl)

New SG-1000 games supported:
- Rally-X (Taiwan) (Chinese Logo) (Unl)
- Rally-X (Taiwan) (English Logo) (Unl)
- Road Fighter (Taiwan) (Chinese Logo) (Unl)
- Road Fighter (Taiwan) (English Logo) (Unl)

Also add CRC-based for 4 PAK All Action (Australia) (Unl).

Changes include:

- Added signals: mapper_4pak_crc, mapper_linear, mapper_sega_locked, mapper_dahjee_a.
- Implemented CRC matches for several carts (linear/MEKA type 11 and Dahjee Type A), and set mapper_4pak via CRC (0x73ED) at reset instead of purely write-based auto-detect.
- Added mapper_linear branch: linear ROM addressing for specific 32KB games.
- Added mapper_sega_locked mode to keep Sega mapper path but block bank writes for 48KB dahjee_typeb games (works around FPGA boot/logo issues).
- Added mapper_dahjee_a: supports linear ROM with 8KB RAM at 0x2000-0x3FFF; adjusted nvram addressing and read paths so that that area reads/writes use the nvram block.
- Updated rom_RD gating and I/O/data mux logic to account for Dahjee Type A and linear mapper cases.
- Updated rom_a_i generation to include sc3000_en, mapper_linear, and mapper_dahjee_a linear-addressing behavior.
- Minor comment and formatting clarifications around mapper selection and OSD mapper lock/force behavior.

These changes enable proper behavior for several regional/unlabeled cartridges and fix boot issues on physical FPGA targets by selecting the correct mapping path and protecting bank registers when required.

* 3 new SG-1000 games supported; Restrict Survivors auto-detect; add ROM CRCs

3 new SG-1000 games supported:
- Castle, The (Taiwan) (Unl)
- Magical Kid Wiz (Taiwan) (Unl)
- Bomberman Special (Taiwan) (Chinese Logo)

Limit Survivors multicart/megacart auto-detection to explicit .sc loads (prevent .sg palette-only downloads from enabling paging) and update related comments. Add CRC entries for Taiwanese releases to improve mapper detection: The Castle (0xF6EE) and Magical Kid Wiz (0xD935) to mapper_linear, and Bomberman Special (0x683D) to mapper_dahjee_a.

---------